### PR TITLE
Revert 4.2.1 update use latest valid version 4.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/mendix-hybrid-app-template",
-  "version": "4.2.1",
+  "version": "4.1.3",
   "description": "Mendix PhoneGap Build app template",
   "scripts": {
     "init": "node init",
@@ -48,7 +48,7 @@
     "/*.md"
   ],
   "dependencies": {
-    "@mendix/mendix-hybrid-app-base": "^4.2.1",
+    "@mendix/mendix-hybrid-app-base": "^4.1.4",
     "global": "^4.3.2",
     "mustache-loader": "^1.4.0"
   },


### PR DESCRIPTION
Reverting version back to 4.1.3 from the unreleased 4.2.1
Reverting to the latest released version of hybrid-app-base 4.1.4.
