### PR TITLE
cordova-sqlite-storage is updated to version 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@mendix/mendix-hybrid-app-template",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/mendix-hybrid-app-template",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@mendix/mendix-hybrid-app-base": "^6.0.2",
+        "@mendix/mendix-hybrid-app-base": "^6.0.3",
         "cordova": "^11.1.0",
         "global": "^4.4.0",
         "mustache-loader": "^1.4.3",
@@ -1789,9 +1789,9 @@
       }
     },
     "node_modules/@mendix/mendix-hybrid-app-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@mendix/mendix-hybrid-app-base/-/mendix-hybrid-app-base-6.0.2.tgz",
-      "integrity": "sha512-Xrbe/khiffOhXbNoc9zoEX0AZxdNZ+1W3cy2nHUulExG1uBqrOED3h9wYRMEWH+iGDrj0R+BS6T4qMYRKau0hA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@mendix/mendix-hybrid-app-base/-/mendix-hybrid-app-base-6.0.3.tgz",
+      "integrity": "sha512-QjZUv0ZrVJEqnzSvse81gPooAJsAm+aWPZ1rLQGTQ4TO5AMIiZIwxOdd65udJ+uBjDdvu6n5Vo/aqFjyatPsbg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.4",
@@ -12540,9 +12540,9 @@
       }
     },
     "@mendix/mendix-hybrid-app-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@mendix/mendix-hybrid-app-base/-/mendix-hybrid-app-base-6.0.2.tgz",
-      "integrity": "sha512-Xrbe/khiffOhXbNoc9zoEX0AZxdNZ+1W3cy2nHUulExG1uBqrOED3h9wYRMEWH+iGDrj0R+BS6T4qMYRKau0hA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@mendix/mendix-hybrid-app-base/-/mendix-hybrid-app-base-6.0.3.tgz",
+      "integrity": "sha512-QjZUv0ZrVJEqnzSvse81gPooAJsAm+aWPZ1rLQGTQ4TO5AMIiZIwxOdd65udJ+uBjDdvu6n5Vo/aqFjyatPsbg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/mendix-hybrid-app-template",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Mendix hybrid app template",
   "scripts": {
     "init": "node init",
@@ -44,7 +44,7 @@
     "scripts/*.js"
   ],
   "devDependencies": {
-    "@mendix/mendix-hybrid-app-base": "^6.0.2",
+    "@mendix/mendix-hybrid-app-base": "^6.0.3",
     "cordova": "^11.1.0",
     "global": "^4.4.0",
     "mustache-loader": "^1.4.3",


### PR DESCRIPTION
### Improvements
- We updated [cordova-sqlite-storage](https://github.com/storesafe/cordova-sqlite-storage) to version 6.1.0